### PR TITLE
updated target property to match server

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const app = express()
 app.use(cors({origin: 'http://localhost:8080'}))
 
 app.use('/api', createProxyMiddleware({
-    target: 'https://app.debricked.com',
+    target: 'https://debricked.com',
     changeOrigin: true
 }))
 


### PR DESCRIPTION
app.debricked.com was causing a redirect to debricked.com and CORS still persisted